### PR TITLE
#4 ticket load brick in Brick Editor

### DIFF
--- a/frontend/src/app/editors/tutorial.rs
+++ b/frontend/src/app/editors/tutorial.rs
@@ -9,7 +9,7 @@ use crate::app::views::tutorial_settings::TutorialSettingsView;
 #[cfg(target_arch = "wasm32")]
 use crate::components::editor_group::EditorGroup;
 #[cfg(target_arch = "wasm32")]
-use crate::interfaces::brick::BrickState;
+use crate::interfaces::brick::{BrickState, StateAction};
 #[cfg(target_arch = "wasm32")]
 use crate::interfaces::catalog;
 #[cfg(target_arch = "wasm32")]
@@ -29,6 +29,7 @@ use yew::prelude::*;
 #[derive(Properties, PartialEq)]
 pub struct TutorialEditorProps {
     pub brick: BrickState,
+    pub brick_dispatcher: UseReducerDispatcher<BrickState>,
     pub tutorial: TutorialViewState,
     pub tutorial_dispatcher: UseReducerDispatcher<TutorialViewState>,
 }
@@ -80,8 +81,13 @@ pub fn tutorial_editor(props: &TutorialEditorProps) -> Html {
 
     let on_select = {
         let dispatcher = props.tutorial_dispatcher.clone();
+        let brick_dispatcher = props.brick_dispatcher.clone();
+        let bricks = bricks.clone();
         Callback::from(move |index: usize| {
             dispatcher.dispatch(TutorialAction::Select(index));
+            if let Some(brick) = bricks.get(index) {
+                brick_dispatcher.dispatch(StateAction::Set(brick.clone()));
+            }
         })
     };
 

--- a/frontend/src/app/page.rs
+++ b/frontend/src/app/page.rs
@@ -29,6 +29,7 @@ fn app() -> Html {
             <Sidebar>
                 <TutorialEditor
                     brick={(*brick).clone()}
+                    brick_dispatcher={brick.dispatcher()}
                     tutorial={(*tutorial).clone()}
                     tutorial_dispatcher={tutorial.dispatcher()}
                 />

--- a/frontend/src/interfaces/brick.rs
+++ b/frontend/src/interfaces/brick.rs
@@ -34,6 +34,7 @@ pub enum StateAction {
     ChangeOffset(f32, f32),
     ChangeContent(String),
     LoadJson(String),
+    Set(BrickState),
 }
 
 impl Reducible for BrickState {
@@ -70,6 +71,7 @@ impl Reducible for BrickState {
                     self
                 }
             },
+            StateAction::Set(brick) => Rc::new(brick),
         }
     }
 }


### PR DESCRIPTION
The plus icon adds the brick on the Brick Editor side to the Tutorial Editor side.

Clicking on the pen icon adapts the changes from the Brick Editor to the selected brick on the Tutorial Editor side. NEW:  when clicking on a brick in the Tutorial Editor, the brick is displayed on the Brick Editor side