### PR TITLE
fix brick catalog

### DIFF
--- a/frontend/src/app/views/brick_catalog_modal.rs
+++ b/frontend/src/app/views/brick_catalog_modal.rs
@@ -23,9 +23,11 @@ fn group_key_from_path(path: &str) -> &str {
 }
 
 #[cfg(target_arch = "wasm32")]
-fn label_from_path(path: &str) -> &str {
+fn label_from_path(path: &str) -> String {
     let file = path.rsplit_once('/').map(|(_, f)| f).unwrap_or(path);
-    file.strip_suffix(".json").unwrap_or(file)
+    file.strip_suffix(".json")
+        .unwrap_or(file)
+        .replace('_', " ")
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/frontend/src/components/card.rs
+++ b/frontend/src/components/card.rs
@@ -46,6 +46,7 @@ pub fn card(props: &CardProps) -> Html {
     html! {
         <div
             class={card_class}
+            title={props.title.clone()}
             onclick={props.onclick.clone()}
             ondblclick={props.ondblclick.clone()}
         >


### PR DESCRIPTION
underscore to whitespace in brick names
brickname displayed when hovering over